### PR TITLE
Rename to ctest2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctest2"
-version = "0.1.0"
+version = "0.3.0"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
   "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
-name = "ctest"
-version = "0.2.22"
+name = "ctest2"
+version = "0.1.0"
 authors = [
   "Alex Crichton <alex@alexcrichton.com>",
-  "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"
+  "Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>",
+  "Yuki Okushi <huyuumi.dev@gmail.com>"
 ]
 license = "MIT/Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/gnzlbg/ctest"
-homepage = "https://github.com/gnzlbg/ctest"
-documentation = "https://docs.rs/ctest"
+repository = "https://github.com/JohnTitor/ctest2"
+homepage = "https://github.com/JohnTitor/ctest2"
+documentation = "https://docs.rs/ctest2"
 description = """
 Automated tests of FFI bindings.
 """

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# ctest
+# ctest2
 
-[![Build Status](https://dev.azure.com/gonzalobg88/ctest/_apis/build/status/gnzlbg.ctest?branchName=master)](https://dev.azure.com/gonzalobg88/ctest/_build/latest?definitionId=5&branchName=master)
 [Documentation][dox]
 
-[dox]: https://docs.rs/ctest
+[dox]: https://docs.rs/ctest2
+
+**Note: This is a fork repository and we intend to use this in libc-test only.**
 
 Automated testing of FFI bindings in Rust. This repository is intended to
 validate the `*-sys` crates that can be found on crates.io to ensure that the
@@ -30,16 +31,16 @@ mylib-sys = { path = "../mylib-sys" }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "0.2"
+ctest2 = "0.2"
 ```
 
 Next, add a build script to `systest/build.rs`:
 
 ```rust
-extern crate ctest;
+extern crate ctest2;
 
 fn main() {
-    let mut cfg = ctest::TestGenerator::new();
+    let mut cfg = ctest2::TestGenerator::new();
 
     // Include the header files where the C APIs are defined
     cfg.header("foo.h")
@@ -87,13 +88,9 @@ and returns information about the C side of things (which is validated in Rust).
 A large amount of configuration can be applied to how the C file is generated,
 you can browse [the documentation][dox].
 
-### Projects using ctest
+### Projects using ctest2
 
 * [libc](https://github.com/rust-lang/libc)
-* [git2-rs](https://github.com/rust-lang/git2-rs)
-* [ssh2-rs](https://github.com/alexcrichton/ssh2-rs)
-* [libz-sys](https://github.com/rust-lang/libz-sys)
-* [openssl-sys](https://github.com/sfackler/rust-openssl)
 
 ### License
 
@@ -109,5 +106,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in ctest by you, as defined in the Apache-2.0 license, shall be
+for inclusion in ctest2 by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -5,7 +5,7 @@ set -ex
 
 run() {
     echo "Building docker container for TARGET=${1}"
-    docker build -t ctest -f ci/docker/$1/Dockerfile ci/
+    docker build -t ctest2 -f ci/docker/$1/Dockerfile ci/
     mkdir -p target
     target=$1
     echo "Running docker"
@@ -21,7 +21,7 @@ run() {
            --volume `pwd`/target:/checkout/target \
            --workdir /checkout \
            --privileged \
-           ctest \
+           ctest2 \
            bash \
            -c 'PATH=/rust/bin:$PATH exec ci/run.sh'
 }

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -10,14 +10,14 @@ set -ex
 mkdir -p target
 rm -rf target/libc || true
 git clone --depth=1 https://github.com/rust-lang/libc target/libc
-mkdir -p target/libc/target/ctest
+mkdir -p target/libc/target/ctest2
 
 case $TARGET in
     *linux*)
-        sed -i 's@ctest = "0.2"@ctest = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
+        sed -i 's@ctest2 = "0.2"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
         ;;
     *apple*)
-        sed -i '' 's@ctest = "0.2"@ctest = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
+        sed -i '' 's@ctest2 = "0.2"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
         ;;
 esac
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! # ctest - an FFI binding validator
+//! # ctest2 - an FFI binding validator
 //!
 //! This library is intended to be used as a build dependency in a separate
 //! project from the main repo to generate tests which can be used to validate
@@ -7,7 +7,7 @@
 //! For example usage, see the [main `README.md`][project] for how to set it
 //! up.
 //!
-//! [project]: https://github.com/alexcrichton/ctest
+//! [project]: https://github.com/alexcrichton/ctest2
 
 #![deny(missing_docs)]
 #![allow(bare_trait_objects)]
@@ -189,7 +189,7 @@ impl TestGenerator {
     /// use std::env;
     /// use std::path::PathBuf;
     ///
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.header("foo.h")
@@ -205,7 +205,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.rust_version(1, 0, 1);
@@ -226,7 +226,7 @@ impl TestGenerator {
     /// use std::env;
     /// use std::path::PathBuf;
     ///
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -245,7 +245,7 @@ impl TestGenerator {
     /// use std::env;
     /// use std::path::PathBuf;
     ///
-    /// use ctest::{TestGenerator, Lang};
+    /// use ctest2::{TestGenerator, Lang};
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.language(Lang::CXX);
@@ -266,7 +266,7 @@ impl TestGenerator {
     /// use std::env;
     /// use std::path::PathBuf;
     ///
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     ///
@@ -289,7 +289,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.out_dir("path/to/output");
@@ -307,7 +307,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.target("x86_64-unknown-linux-gnu");
@@ -325,7 +325,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.define("_GNU_SOURCE", None)
@@ -354,7 +354,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.cfg("foo", None) // cfg!(foo)
@@ -385,7 +385,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.type_name(|ty, is_struct, is_union| {
@@ -415,7 +415,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.field_name(|_s, field| {
@@ -437,7 +437,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::{TestGenerator, VolatileItemKind::StructField};
+    /// use ctest2::{TestGenerator, VolatileItemKind::StructField};
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.volatile_item(|i| {
@@ -463,7 +463,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::{TestGenerator};
+    /// use ctest2::{TestGenerator};
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.array_arg(|i, n| {
@@ -490,7 +490,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.const_cname(|c| {
@@ -515,7 +515,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_field(|s, field| {
@@ -540,7 +540,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_field_type(|s, field| {
@@ -565,7 +565,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_signededness(|s| {
@@ -591,7 +591,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_fn(|s| {
@@ -617,7 +617,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_static(|s| {
@@ -660,7 +660,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_const(|s| {
@@ -685,7 +685,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_type(|s| {
@@ -711,7 +711,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_struct(|s| {
@@ -738,7 +738,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.skip_roundtrip(|s| {
@@ -765,7 +765,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.fn_cname(|rust, link_name| link_name.unwrap_or(rust).to_string());
@@ -793,7 +793,7 @@ impl TestGenerator {
     /// # Examples
     ///
     /// ```no_run
-    /// use ctest::TestGenerator;
+    /// use ctest2::TestGenerator;
     ///
     /// let mut cfg = TestGenerator::new();
     /// cfg.generate("../path/to/libfoo-sys/lib.rs", "all.rs");

--- a/testcrate/Cargo.toml
+++ b/testcrate/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 
 [build-dependencies]
-ctest = { path = ".." }
+ctest2 = { path = ".." }
 cc = "1.0"
 
 [dependencies]

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -1,5 +1,5 @@
 extern crate cc;
-extern crate ctest;
+extern crate ctest2;
 
 fn main() {
     use std::env;
@@ -24,7 +24,7 @@ fn main() {
         .compile("libt2.a");
     println!("cargo:rerun-if-changed=src/t2.c");
     println!("cargo:rerun-if-changed=src/t2.h");
-    ctest::TestGenerator::new()
+    ctest2::TestGenerator::new()
         .header("t1.h")
         .include("src")
         .fn_cname(|a, b| b.unwrap_or(a).to_string())
@@ -39,7 +39,7 @@ fn main() {
         .array_arg(t1_arrays)
         .skip_roundtrip(|n| n == "Arr")
         .generate("src/t1.rs", "t1gen.rs");
-    ctest::TestGenerator::new()
+    ctest2::TestGenerator::new()
         .header("t2.h")
         .include("src")
         .type_name(move |ty, is_struct, is_union| match ty {
@@ -51,9 +51,9 @@ fn main() {
         .skip_roundtrip(|_| true)
         .generate("src/t2.rs", "t2gen.rs");
 
-    ctest::TestGenerator::new()
+    ctest2::TestGenerator::new()
         .header("t1.h")
-        .language(ctest::Lang::CXX)
+        .language(ctest2::Lang::CXX)
         .include("src")
         .fn_cname(|a, b| b.unwrap_or(a).to_string())
         .type_name(move |ty, is_struct, is_union| match ty {
@@ -67,9 +67,9 @@ fn main() {
         .array_arg(t1_arrays)
         .skip_roundtrip(|n| n == "Arr")
         .generate("src/t1.rs", "t1gen_cxx.rs");
-    ctest::TestGenerator::new()
+    ctest2::TestGenerator::new()
         .header("t2.h")
-        .language(ctest::Lang::CXX)
+        .language(ctest2::Lang::CXX)
         .include("src")
         .type_name(move |ty, is_struct, is_union| match ty {
             "T2Union" => ty.to_string(),
@@ -81,8 +81,8 @@ fn main() {
         .generate("src/t2.rs", "t2gen_cxx.rs");
 }
 
-fn t1_volatile(i: ctest::VolatileItemKind) -> bool {
-    use ctest::VolatileItemKind::*;
+fn t1_volatile(i: ctest2::VolatileItemKind) -> bool {
+    use ctest2::VolatileItemKind::*;
     match i {
         StructField(ref n, ref f) if n == "V" && f == "v" => true,
         Static(ref n) if n == "vol_ptr" => true,


### PR DESCRIPTION
I'm going to add some work in this repository to remove syntex. So, I'd rename this crate to ctest2 and publish to crates.io to make things stable when used in libc.