### PR TITLE
Add support for the Haiku target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1114,6 +1114,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         ("redox", "unix", "")
     } else if target.contains("vxworks") {
         ("vxworks", "unix", "")
+    } else if target.contains("haiku") {
+        ("haiku", "unix", "")
     } else {
         panic!("unknown os/family: {}", target)
     };


### PR DESCRIPTION
This opens the way for automated testing of libc on Haiku.