### PR TITLE
Fix `unaligned_references` warning

### DIFF
--- a/testcrate/src/bin/t1.rs
+++ b/testcrate/src/bin/t1.rs
@@ -1,6 +1,5 @@
 #![cfg(not(test))]
 #![deny(warnings)]
-#![allow(unaligned_references)]
 
 use libc::*;
 use testcrate::t1::*;

--- a/testcrate/src/bin/t1_cxx.rs
+++ b/testcrate/src/bin/t1_cxx.rs
@@ -1,6 +1,5 @@
 #![cfg(not(test))]
 #![deny(warnings)]
-#![allow(unaligned_references)]
 
 use libc::*;
 use testcrate::t1::*;

--- a/testcrate/src/bin/t2.rs
+++ b/testcrate/src/bin/t2.rs
@@ -1,6 +1,5 @@
 #![cfg(not(test))]
 #![deny(warnings)]
-#![allow(unaligned_references)]
 
 use testcrate::t2::*;
 

--- a/testcrate/src/bin/t2_cxx.rs
+++ b/testcrate/src/bin/t2_cxx.rs
@@ -1,6 +1,5 @@
 #![cfg(not(test))]
 #![deny(warnings)]
-#![allow(unaligned_references)]
 
 use testcrate::t2::*;
 

--- a/testcrate/tests/all.rs
+++ b/testcrate/tests/all.rs
@@ -15,22 +15,22 @@ fn cmd(name: &str) -> Command {
 #[test]
 fn t1() {
     let (o, status) = output(&mut cmd("t1"));
-    assert!(status.success(), o);
-    assert!(!o.contains("bad "), o);
+    assert!(status.success(), "{}", o);
+    assert!(!o.contains("bad "), "{}", o);
     eprintln!("o: {}", o);
 }
 
 #[test]
 fn t1_cxx() {
     let (o, status) = output(&mut cmd("t1_cxx"));
-    assert!(status.success(), o);
-    assert!(!o.contains("bad "), o);
+    assert!(status.success(), "{}", o);
+    assert!(!o.contains("bad "), "{}", o);
 }
 
 #[test]
 fn t2() {
     let (o, status) = output(&mut cmd("t2"));
-    assert!(!status.success(), o);
+    assert!(!status.success(), "{}", o);
     let errors = [
         "bad T2Foo signed",
         "bad T2TypedefFoo signed",
@@ -74,7 +74,7 @@ fn t2() {
 #[test]
 fn t2_cxx() {
     let (o, status) = output(&mut cmd("t2_cxx"));
-    assert!(!status.success(), o);
+    assert!(!status.success(), "{}", o);
     let errors = [
         "bad T2Foo signed",
         "bad T2TypedefFoo signed",


### PR DESCRIPTION
Fixes #22