### PR TITLE
Allow to subtract in constants

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2208,6 +2208,7 @@ impl<'a> Generator<'a> {
                 let e2 = self.expr2str(e2);
                 match op.node {
                     ast::BinOpKind::Add => format!("{} + {}", e1, e2),
+                    ast::BinOpKind::Sub => format!("{} - {}", e1, e2),
                     _ => panic!("unknown op: {:?}", op),
                 }
             }


### PR DESCRIPTION
This is the origin of the bug in https://github.com/rust-lang/libc/pull/2451.

Once merged, please publish a new version afterwards.