### PR TITLE
ci: actually patch libc-test's Cargo.toml

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -14,10 +14,10 @@ mkdir -p target/libc/target/ctest2
 
 case $TARGET in
     *linux*)
-        sed -i 's@ctest2 = "0.2"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
+        sed -E -i 's@ctest2 = "[0-9\.]+"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
         ;;
     *apple*)
-        sed -i '' 's@ctest2 = "0.2"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
+        sed -E -i '' 's@ctest2 = "[0-9\.]+"@ctest2 = { path = "../../.." }@g' target/libc/libc-test/Cargo.toml
         ;;
 esac
 


### PR DESCRIPTION
Previously, CI was running against the latest version at crates.io due to a mismatching regex, instead of git HEAD.