### PR TITLE
Fix QNX/nto support of 7.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1123,15 +1123,17 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         ("vxworks", "unix", "")
     } else if target.contains("haiku") {
         ("haiku", "unix", "")
-    } else if target.contains("qnx") {
-        // Set an environment string if provided, empty str otherwise
-        let before_env = "-qnx-";
-        let env = target
+    } else if target.contains("nto-qnx") {
+        let before_env = "nto-qnx";
+        let version = target
             .rfind(before_env)
             .map(|i| &target[i + before_env.len()..])
-            .or(Some(""))
             .unwrap();
-        ("qnx", "unix", env)
+        let env = match version {
+            "7.1.0" => "nto71",
+            _ => panic!("Uknown version"),
+        };
+        ("nto", "unix", env)
     } else {
         panic!("unknown os/family: {}", target)
     };


### PR DESCRIPTION
This fixes handling of QNX/nto after it has finally been merged to master of Rust (https://github.com/rust-lang/rust/pull/102701). There has been a small change of how targets are named.