### PR TITLE
Don't use periods in QNX/Neutrino target names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,8 +1130,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
             .map(|i| &target[i + before_env.len()..])
             .unwrap();
         let env = match version {
-            "7.1.0" => "nto71",
-            _ => panic!("Uknown version"),
+            "710" => "nto71",
+            _ => panic!("Unknown version"),
         };
         ("nto", "unix", env)
     } else {


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/104523