### PR TITLE
Add a config default for QNX 7.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1132,6 +1132,7 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
             .map(|i| &target[i + before_env.len()..])
             .unwrap();
         let env = match version {
+            "700" => "nto70",
             "710" => "nto71",
             _ => panic!("Unknown version"),
         };


### PR DESCRIPTION
I am adding `std` support for QNX 7.0, a previous release of QNX Neutrino RTOS, and using ctest2 to test necessary changes to libc.

See for reference:
- https://github.com/rust-lang/rust/blob/master/src/doc/rustc/src/platform-support/nto-qnx.md
- https://github.com/JohnTitor/ctest2/pull/46