### PR TITLE
Add support for AIX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1138,6 +1138,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         ("nto", "unix", env)
     } else if target.contains("linux-ohos") {
         ("linux", "unix", "ohos")
+    } else if target.contains("aix") {
+        ("aix", "unix", "")
     } else {
         panic!("unknown os/family: {}", target)
     };


### PR DESCRIPTION
AIX is currently a tier-3 target in Rust. This crate is required in crate `libc`'s libc-test.