### PR TITLE
Replace references of static externs to addr_of!. We need to do this …

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.56.0 # MSRV
+          - 1.63.0 # MSRV
           - stable
           - beta
           - nightly
@@ -29,7 +29,7 @@ jobs:
         run: TOOLCHAIN=${{ matrix.version }} TARGET=${{ matrix.target }} sh ./ci/install-rust.sh
 
       - name: Check MSRV
-        if: matrix.version == '1.56.0'
+        if: matrix.version == '1.63.0'
         run: cargo check
 
       # FIXME: Some symbols cause multiple definitions error on the same line:
@@ -38,9 +38,9 @@ jobs:
       # /home/runner/work/ctest2/ctest2/target/debug/deps/libtestcrate-a072d428f9532abb.rlib(t1.o):
       # /home/runner/work/ctest2/ctest2/testcrate/src/t1.h:65: first defined here
       # - name: Run tests
-      #   if: matrix.version != '1.56.0'
+      #   if: matrix.version != '1.63.0'
       #   run: cargo test --all -- --nocapture
 
       - name: Run libc tests
-        if: matrix.version != '1.56.0'
+        if: matrix.version != '1.63.0'
         run: sh ./ci/run-docker.sh ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ Automated tests of FFI bindings.
 """
 include = ["src/lib.rs", "LICENSE-*", "README.md"]
 edition = "2021"
-rust-version = "1.56.0"
+rust-version = "1.63.0"
 
 [dependencies]
 garando_syntax = "0.1"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ APIs in Rust match the APIs defined in C.
 
 ## MSRV (Minimum Supported Rust Version)
 
-The MSRV is 1.56.0 because of the transitive dependencies.
+The MSRV is 1.63.0 because of the transitive dependencies.
 Note that MSRV may be changed anytime by dependencies.
 
 ## Example

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
   gcc libc6-dev ca-certificates linux-headers-generic git

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1716,7 +1716,8 @@ impl<'a> Generator<'a> {
                     fn __test_static_{name}() -> {ty};
                 }}
                 unsafe {{
-                    same(*(&{name} as *const _ as *const {ty}) as usize,
+                    // We must use addr_of! here because of https://github.com/rust-lang/rust/issues/114447
+                    same(*(std::ptr::addr_of!({name}) as *const {ty}) as usize,
                          __test_static_{name}() as usize,
                          "{name} static");
                 }}
@@ -1760,7 +1761,8 @@ impl<'a> Generator<'a> {
                     fn __test_static_{name}() -> *{mutbl} {ty};
                 }}
                 unsafe {{
-                    same(&{name} as *const _ as usize,
+                    // We must use addr_of! here because of https://github.com/rust-lang/rust/issues/114447
+                    same(std::ptr::addr_of!({name}) as usize,
                          __test_static_{name}() as usize,
                          "{name} static");
                 }}
@@ -1804,7 +1806,8 @@ impl<'a> Generator<'a> {
                     fn __test_static_{name}() -> *{mutbl} {ty};
                 }}
                 unsafe {{
-                    same(&{name} as *const _ as usize,
+                    // We must use addr_of! here because of https://github.com/rust-lang/rust/issues/114447
+                    same(std::ptr::addr_of!({name}) as usize,
                          __test_static_{name}() as usize,
                          "{name} static");
                 }}


### PR DESCRIPTION
…because of https://github.com/rust-lang/rust/issues/114447 .

I need this, because I plan to send PR to crate libc, which will add `environ` static extern for UNIX. Unfortunately, `environ` generates annoying warning during testing due to https://github.com/rust-lang/rust/issues/114447 , so I'm sending this PR to ctest2 first.

I tested this ctest2 PR with my fork of crate libc, which adds `environ`, and all works great.

Also, even if you opposed to proposed crate libc change, this ctest2 PR is of general usefulness anyway.

Also, this ctest2 PR always unconditionally generates `addr_of!` invocation. This is okay, because ctest2's MSRV is 1.56.0, and `addr_of!` was added in 1.51.0.

Please, make ctest2 release after this PR is applied