### PR TITLE
Add support for alternative network stack io-sock on QNX 7.1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1136,6 +1136,7 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
             "700" => "nto70",
             "710" => "nto71",
             "710_iosock" => "nto71_iosock",
+            "800" => "nto80",
             _ => panic!("Unknown version: {version}"),
         };
         ("nto", "unix", env)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1135,7 +1135,8 @@ fn default_cfg(target: &str) -> Vec<(String, Option<String>)> {
         let env = match version {
             "700" => "nto70",
             "710" => "nto71",
-            _ => panic!("Unknown version"),
+            "710_iosock" => "nto71_iosock",
+            _ => panic!("Unknown version: {version}"),
         };
         ("nto", "unix", env)
     } else if target.contains("linux-ohos") {


### PR DESCRIPTION
This change:
- Adds support for new targets and env value
- Gives users a bit more information about unknown versions

This depends on rust-lang/rust/pull/133631

CC: @jonathanpallant @japaric @gh-tr @AkhilTThomas